### PR TITLE
Fix copier _src_path not pointing to template repository

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # This file is managed by Copier; DO NOT EDIT OR REMOVE.
 _commit: v0.1.6
-_src_path: copier-template-pre-commit-mirrors
+_src_path: git@github.com:Quantco/copier-template-pre-commit-mirrors.git
 conda_package: yamllint
 description: This hook runs yamllint. yamllint does not only check for syntax validity,
     but for weirdnesses like key repetition and cosmetic problems such as lines length,


### PR DESCRIPTION
For details see https://github.com/Quantco/copier-template-pre-commit-mirrors/issues/13